### PR TITLE
ID、商品名ソートしない

### DIFF
--- a/mock/mock01_quotaion.html
+++ b/mock/mock01_quotaion.html
@@ -112,8 +112,8 @@
              label="Table Options"
              :items= items
              :fields="[
-                {  key: 'id', label: 'ID',  sortable: true,class:'text-center' },
-                {  key: 'hinmei', label: '商品名' ,  sortable: true},
+                {  key: 'id', label: 'ID', class:'text-center' },
+                {  key: 'hinmei', label: '商品名' },
                 {  key: 'suryo',   label: '数量' },
                 {  key: 'unit',  label: '単位' },
                 {  key: 'tanka',  label: '単価' },

--- a/mock/mock_invoice.html
+++ b/mock/mock_invoice.html
@@ -178,8 +178,8 @@
                label="Table Options"
                :items= items
                :fields="[
-                  {  key: 'id', label: 'ID',  sortable: true,class:'text-center' },
-                  {  key: 'hinmei', label: '商品名' ,  sortable: true},
+                  {  key: 'id', label: 'ID',  class:'text-center' },
+                  {  key: 'hinmei', label: '商品名' },
                   {  key: 'suryo',   label: '数量' },
                   {  key: 'tanka',  label: '単価' },
                   {  key: 'kingaku', label: '金額' }


### PR DESCRIPTION
IDはソートしない。
商品名はソータブルだったが、Vue.jsのバグが発覚。b-tableのフィールドをinput対応にしたとき、ソートを行うと入力内容が多重化する。この問題は深いため、現時点では商品名もソートしないということで一時的対応とする。