### PR TITLE
請求番号の自動生成ロジック

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from app import db, app, ma
 from datetime import datetime
 from datetime import date
@@ -87,15 +88,20 @@ class Item(db.Model):
     # invoice_items=db.relationship('Invoice_Item',backref='items')
     # quotation_items=db.relationship('Quotation_Item',backref='items')
 
+fmt_str_invoice = "{0:請%y%m%d}";   
+def edited_invoice_number(context):
+    str_id = str(context.get_current_parameters()['id'])
+    today = date.today() 
+    return fmt_str_invoice.format(today) + "_" + str_id
 
 class Invoice(db.Model):
 
     __tablename__ = 'invoices'
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(db.Integer,primary_key=True )
     customerId = db.Column(db.Integer, db.ForeignKey('customers.id'))
     customerName = db.Column(db.String)
-    applyNumber = db.Column(db.Integer)
+    applyNumber = db.Column(db.String,default=edited_invoice_number)
     applyDate = db.Column(db.Date)
     expiry = db.Column(db.Date)
     title = db.Column(db.String)
@@ -107,6 +113,7 @@ class Invoice(db.Model):
                           default=datetime.now, onupdate=datetime.now)
     invoice_items = db.relationship(
         'Invoice_Item', backref='invoice', uselist=True, cascade='all, delete',)
+
 
 
 class Invoice_Item(db.Model):

--- a/app/seeder.py
+++ b/app/seeder.py
@@ -66,11 +66,11 @@ def seeder():
     # -----Invoices-----
     print('----Invoices-----')
     invoices = [
-        Invoice(id=1, customerId=1, customerName='○○株式会社', applyNumber=1000001, applyDate=date(2022, 1, 1), expiry=date(2022, 1, 1),
+        Invoice(id=1, customerId=1, customerName='○○株式会社',  applyDate=date(2022, 1, 1), expiry=date(2022, 1, 1),
                 title='○○株式会社への請求書', memo='これは請求書のメモです', remarks='これは請求書の備考です', isTaxExp=True),
-        Invoice(id=2, customerId=2, customerName="○○有限会社", applyNumber=1000002, applyDate=date(2022, 1, 1), expiry=date(2022, 1, 1),
+        Invoice(id=2, customerId=2, customerName="○○有限会社",  applyDate=date(2022, 1, 1), expiry=date(2022, 1, 1),
                 title='○○有限会社への請求書', memo='これは請求書のメモです', remarks='これは請求書の備考です', isTaxExp=True),
-        Invoice(id=3, customerId=3, customerName="○○商事", applyNumber=1000003, applyDate=date(2022, 1, 1), expiry=date(2022, 1, 1),
+        Invoice(id=3, customerId=3, customerName="○○商事",  applyDate=date(2022, 1, 1), expiry=date(2022, 1, 1),
                 title='○○商事への請求書', memo='これは請求書のメモです', remarks='これは請求書の備考です', isTaxExp=True),
     ]
     db.session.add_all(invoices)


### PR DESCRIPTION
請求番号の自動生成ロジックを考えた。

・invoice.applyNumber のdefault指定で請求番号自動生成ロジックedited_invoice_numberを呼ぶ。
・edited_invoice_numberは本日の日付に｢請｣を付加し、さらに末尾にIDを付加する。

・invoice.applyNumberはもはや数値項目ではないので、モデルのデータ型はStringにする。
・seeder.pyの請求番号は自動取得なので、消去。