### PR TITLE
得意先周りの非表示機能実装。その他修正

### DIFF
--- a/app/templates/customer.html
+++ b/app/templates/customer.html
@@ -97,8 +97,9 @@
                     <b-col cols="10">
                         <b-card border-variant="white" class="mb-3 text-center" header="得意先一覧"
                             header-border-variant="light">
+                            <b-form-checkbox v-model="isHideOption">表示しないオプションがOFFのもののみ表示</b-form-checkbox>
                             <b-table responsive hover small id="customertable" sort-by="ID" small label="Table Options"
-                                :items=customers :fields="[
+                                :items=customersIndicateIndex :fields="[
                       {  key: 'update', label: '' },
                       {  key: 'id', label: 'No.' },
                       {  key: 'customerName', label: '得意先名' },
@@ -305,6 +306,7 @@
                 data: {
                     customers: [],               //全件customer
                     customer: [],                //選択中のcustomer
+                    isHideOption: false,            // trueの時、customer.isHide=falseのもののみindexに表示
                 },
                 methods: {
                     // ---Customers---
@@ -416,9 +418,14 @@
                         return this.$route.query.page;
                     },
                     modeName() {
-                        //return this.$route.query.mode;
                         return localStorage.getItem('wMode');
                     },
+                    customersIndicateIndex: function () {
+                        if (this.isHideOption === true) {
+                            return this.customers.filter(customer => customer.isHide === false)
+                        }
+                        return this.customers;
+                    }
                 }
             })
 

--- a/app/templates/invoice.html
+++ b/app/templates/invoice.html
@@ -202,6 +202,8 @@
                                                     size="sm">
                                                 </b-form-input>
                                             </b-form-group>
+                                            <b-form-checkbox v-model="isHideOption">表示しないオプションがOFFのもののみ表示
+                                            </b-form-checkbox>
                                             <b-table hover striped small sort-by="ID" id="customer-table"
                                                 :items="searchCustomers" @row-clicked="customerSelect"
                                                 label="Table Options" :fields="[
@@ -353,13 +355,6 @@
                                 </b-row>
                             </template>
 
-                            <!-- <template #table-colgroup="data">
-                            <col v-for="field in data.fields" :key="field.key" :style="{ width:
-                          field.key == 'id' ? '2%':
-                          field.key == 'detail' ? '1%':
-                          field.key == 'hinmei' ? '10%': '5%'}">
-                        </template> -->
-
                             <template v-slot:cell(delete)="data">
                                 <b-button variant="danger" class="fas fa-trash-alt"
                                     @click="deleteInvoiceItem(data.item)">
@@ -453,6 +448,7 @@
                     units: [],
                     categories: [],
                     makers: [],
+                    isHideOption: false,        // trueの時、customer.isHide=falseのもののみindexに表示
                 },
                 methods: {
                     // ---Invoices---
@@ -701,9 +697,15 @@
                     },
                     // 得意先選択モーダルの検索機能
                     searchCustomers: function () {
+                        if (this.isHideOption === true) {
+                            return this.customers.filter(customer => {
+                                return (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord)) &&
+                                    customer.isHide === false;
+                            });
+                        }
                         return this.customers.filter(customer => {
-                            return customer.customerName.includes(this.searchCustomerWord) || String(customer.id).includes(this.searchCustomerWord);
-                        })
+                            return (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord));
+                        });
                     },
                     // 商品選択モーダルの検索機能
                     searchItems: function () {

--- a/app/templates/quotation.html
+++ b/app/templates/quotation.html
@@ -201,6 +201,8 @@
                                                     size="sm">
                                                 </b-form-input>
                                             </b-form-group>
+                                            <b-form-checkbox v-model="isHideOption">表示しないオプションがOFFのもののみ表示
+                                            </b-form-checkbox>
                                             <b-table hover striped small sort-by="ID" id="customer-table"
                                                 :items="searchCustomers" @row-clicked="customerSelect"
                                                 label="Table Options" :fields="[
@@ -352,13 +354,6 @@
                                 </b-row>
                             </template>
 
-                            <!-- <template #table-colgroup="data">
-                            <col v-for="field in data.fields" :key="field.key" :style="{ width:
-                          field.key == 'id' ? '2%':
-                          field.key == 'detail' ? '1%':
-                          field.key == 'hinmei' ? '10%': '5%'}">
-                        </template> -->
-
                             <template v-slot:cell(delete)="data">
                                 <b-button variant="danger" class="fas fa-trash-alt"
                                     @click="deleteQuotationItem(data.item)">
@@ -453,6 +448,7 @@
                     units: [],
                     categories: [],
                     makers: [],
+                    isHideOption: false,        // trueの時、customer.isHide=falseのもののみindexに表示
                 },
                 methods: {
                     // ---Quotations---
@@ -704,9 +700,15 @@
                     },
                     // 得意先選択モーダルの検索機能
                     searchCustomers: function () {
+                        if (this.isHideOption === true) {
+                            return this.customers.filter(customer => {
+                                return (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord)) &&
+                                    customer.isHide === false;
+                            });
+                        }
                         return this.customers.filter(customer => {
-                            return customer.customerName.includes(this.searchCustomerWord) || String(customer.id).includes(this.searchCustomerWord);
-                        })
+                            return (customer.customerName?.includes(this.searchCustomerWord) || String(customer.id)?.includes(this.searchCustomerWord));
+                        });
                     },
                     // 商品選択モーダルの検索機能
                     searchItems: function () {


### PR DESCRIPTION
- 得意先ページ・請求書の得意先選択モーダル・見積書の得意先選択モーダルに非表示機能の追加。
   - 関連Issue：得意先ページ。得意先情報一覧非表示機能を追加する #372 
- 請求書・見積書ページを開いた時に出るエラーの解消
   - (検索対象の得意先カラムにnullが入っている際にエラー)
- 請求書・見積書不用箇所削除